### PR TITLE
Updated link and name order in About PyDV and copyright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .DS_Store
 mypdv
 dist
+pydv/doc/_build

--- a/pydv/pdvplot.py
+++ b/pydv/pdvplot.py
@@ -428,7 +428,7 @@ class Plotter(QMainWindow):
     def __viewCopyright(self):
         msg = self.tr('<b><p style="font-family:verdana;">Copyright &copy; 2011-2020, Lawrence Livermore National Security, LLC. \
                       Produced at the Lawrence Livermore National Laboratory</p> \
-                      <p style="font-family:verdana;">Written by Mason Kwiat, Douglas S. Miller, and Kevin Griffin</p> \
+                      <p style="font-family:verdana;">Written by Kevin Griffin, Mason Kwiat, and Douglas S. Miller</p> \
                       <p style="font-family:verdana;">e-mail: griffin28@llnl.gov or dougmiller@llnl.gov</p> \
                       <p style="font-family:verdana;">LLNL-CODE-507071</p> \
                       <p style="font-family:verdana;">All rights reserved.</p></b> \
@@ -517,9 +517,9 @@ class Plotter(QMainWindow):
     def __aboutPyDV(self):
         QMessageBox.about(self, self.tr('About PyDV'), self.tr('<h2>About PyDV</h2>'
                                                                '<p style="font-family:courier; font-size:40%;">version 3.0</p>'
-                                                               '<p style="font-family:verdana;"><a href="https://lc.llnl.gov/confluence/display/PYDV/PyDV%3A+Python+Data+Visualizer">PyDV</a> is a 1D graphics tool, heavily based on the ULTRA plotting tool.</p>'
+                                                               '<p style="font-family:verdana;"><a href="https://pydv.readthedocs.io/en/latest/">PyDV</a> is a 1D graphics tool, heavily based on the ULTRA plotting tool.</p>'
                                                                '<p style="font-family:courier; font-size:-1;">Copyright &copy; 2011-2020, Lawrence Livermore National Security, LLC.</p>'
-                                                               '<p style="font-family:veranda; font-size:80%;">Written by: Mason Kwiat, Douglas S. Miller, and Kevin Griffin</p>'
+                                                               '<p style="font-family:veranda; font-size:80%;">Written by: Kevin Griffi, Mason Kwiat, and Douglas S. Miller</p>'
                                                                '<p style="font-family:veranda; font-size:80%;">email: griffin28@llnl.gov</p>'
                                                                '<p style="font-family:veranda; font-size:60%;"><i>LLNL-CODE-507071, All rights reserved.</i></p>'))
 


### PR DESCRIPTION
Resolves #127 
Updated link and name order in About PyDV and copyright message boxes. Added _build directory back to .gitignore.